### PR TITLE
Fix path and allow access to block devices

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -43,6 +43,7 @@ apps:
       - hardware-observe
       - mount-observe
       - polkit
+      - block-devices
     slots:
       - udisks2
     daemon-scope: system
@@ -59,8 +60,8 @@ layout:
     bind: $SNAP/usr/var/lib/udisks2
   /usr/etc/udisks2:
     bind: $SNAP/usr/etc/udisks2
-  /etc/libblockdev/conf.d:
-    bind: $SNAP/etc/libblockdev/conf.d
+  /etc/libblockdev/3/conf.d:
+    bind: $SNAP/etc/libblockdev/3/conf.d
 
 parts:
   udisks2-copyright:


### PR DESCRIPTION
One of the paths in the `layout` part is wrong.

Also, the `block-devices` plug is required to allow the daemon to have access to the devices and mount them.