### PR TITLE
Fix read-only-fs error

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -57,7 +57,7 @@ apps:
 
 layout:
   /usr/var/lib/udisks2:
-    bind: $SNAP/usr/var/lib/udisks2
+    type: tmpfs
   /usr/etc/udisks2:
     bind: $SNAP/usr/etc/udisks2
   /etc/libblockdev/3/conf.d:


### PR DESCRIPTION
When mounting a filesystem as a non-root user, an error is shown in the system log:

`udisksd[62203]: Error setting state data mounted-fs-persistent: Failed to create file “/usr/var/lib/udisks2/mounted-fs-persistent.B71852”: Read-only file system (g-file-error-quark, 8)`

This PR fixes it.