### PR TITLE
Initial upgrade of udisks2-snap for core26

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,12 +1,13 @@
 name: udisks2
-version: 2.10.1-5-dev
+version: 2.10.91-1-dev
 summary: Storage devices management service
 description: |
     Udisks2 provides a dbus service that can query and manager
     storages devices as well as a command-line tool.
 confinement: strict
-grade: stable
-base: core24
+grade: devel
+base: core26
+build-base: devel
 
 lint:
   ignore:
@@ -93,6 +94,7 @@ parts:
       - libblockdev-crypto-dev
       - libpolkit-agent-1-dev
       - libpolkit-gobject-1-dev
+      - libblockdev-smart-dev
       - gettext
       - xsltproc
       - docbook-xsl
@@ -102,21 +104,21 @@ parts:
       - libblockdev-crypto3
       - libblockdev-fs3
       - libblockdev-loop3
-      - libblockdev-loop3
       - libblockdev-mdraid3
       - libblockdev-nvme3
       - libblockdev-part3
       - libblockdev-swap3
-      - libblockdev-swap3
       - libblockdev-utils3
       - libblockdev3
+      - libblockdev-smart3
       - libgudev-1.0-0
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/usr
       - --enable-fhs-media
+      - --with-udevdir=/usr/lib/udev
     source-type: git
-    source-branch: applied/ubuntu/noble-updates
+    source-branch: applied/ubuntu/resolute
     source: https://git.launchpad.net/ubuntu/+source/udisks2
     override-pull: |
       craftctl default

--- a/spread.yaml
+++ b/spread.yaml
@@ -45,8 +45,8 @@ backends:
     plan: n2-standard-2
     halt-timeout: 2h
     systems:
-      - ubuntu-core-24-64:
-          image: ubuntu-24.04-64
+      - ubuntu-core-26-64:
+          image: ubuntu-26.04-64
           workers: 8
           storage: 20G
     prepare: |
@@ -56,7 +56,7 @@ backends:
   qemu:
     memory: 4G
     systems:
-      - ubuntu-core-24-64:
+      - ubuntu-core-26-64:
           username: test
           password: test
           bios: uefi
@@ -85,14 +85,12 @@ prepare: |
   "$SYSTEMSNAPSTESTLIB"/prepare.sh
 
 prepare-each: |
-  # install the normal from store first to get auto-connected on plugs
-  snap install udisks2 --channel=24/edge
-  
-  # now install the one built by tests
+  snap wait system seed.loaded
   snap install --dangerous "${PROJECT_PATH}/${SNAP_NAME}"*_amd64.snap
   snap connect udisks2:udisks2-client udisks2:udisks2
   snap connect udisks2:hardware-observe
   snap connect udisks2:mount-observe
+  snap connect udisks2:block-devices
 
 restore-each: |
   snap remove --purge udisks2


### PR DESCRIPTION
Port the udisks2 snap to the core26 base, tracking the Ubuntu 26.04 (Resolute) package.

All tests passed locally: 
```
2026-04-02 12:45:28 Project content is packed for delivery (23.62MB).                                                                         
2026-04-02 12:45:28 If killed, discard servers with: spread -reuse-pid=357235 -discard                                                        
2026-04-02 12:45:28 Allocating qemu:ubuntu-core-26-64...
2026-04-02 12:45:28 Nico debug: QEMU cmdline: /usr/bin/qemu-system-x86_64 -drive if=pflash,format=raw,file=/home/marko.puric@canonical.com/OVM
F_VARS.fd,unit=1 -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.fd,unit=0 -nographic -enable-kvm -snapshot -m 4096 
-net nic -net user,hostfwd=tcp:127.0.0.1:59333-:22 -serial telnet:127.0.0.1:59433,server,nowait -monitor telnet:127.0.0.1:59533,server,nowait 
/home/marko.puric@canonical.com/.spread/qemu/ubuntu-core-26-64.img
2026-04-02 12:45:28 Serial and monitor for qemu:ubuntu-core-26-64 available at ports 59433 and 59533.
2026-04-02 12:45:28 Waiting for qemu:ubuntu-core-26-64 to make SSH available...
2026-04-02 12:45:29 Allocated qemu:ubuntu-core-26-64.
2026-04-02 12:45:29 Connecting to qemu:ubuntu-core-26-64...
2026-04-02 12:46:26 Connected to qemu:ubuntu-core-26-64 at localhost:59333.
2026-04-02 12:46:26 Sending project content to qemu:ubuntu-core-26-64...
2026-04-02 12:46:27 Preparing qemu:ubuntu-core-26-64 (qemu:ubuntu-core-26-64)...
2026-04-02 12:46:27 Preparing qemu:ubuntu-core-26-64:tests/smoke (qemu:ubuntu-core-26-64)...
2026-04-02 12:46:30 Executing qemu:ubuntu-core-26-64:tests/smoke (qemu:ubuntu-core-26-64) (1/1)...
2026-04-02 12:46:31 Restoring qemu:ubuntu-core-26-64:tests/smoke (qemu:ubuntu-core-26-64)...
2026-04-02 12:46:34 Discarding qemu:ubuntu-core-26-64...
2026-04-02 12:46:34 Successful tasks: 1
2026-04-02 12:46:34 Aborted tasks: 0
```

@nicoharnois, @alfonsosanchezbeato 