### PR TITLE
snapcraft.yaml: fix linter warnings

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -20,6 +20,24 @@ lint:
       - usr/lib/**/libnvme*.so*
       # Used by libbd_crypto
       - usr/lib/**/libvolume_key.so*
+      # Used by libbd_smart at runtime
+      - usr/lib/**/libatasmart.so*
+      # Linked by libbd_crypto and libvolume_key
+      - usr/lib/**/libnss3.so*
+      - usr/lib/**/libnssutil3.so*
+      # NSPR libs linked by libnss3
+      - usr/lib/**/libnspr4.so*
+      - usr/lib/**/libplc4.so*
+      - usr/lib/**/libplds4.so*
+      # NSS crypto modules loaded by libnss3
+      - usr/lib/**/libfreebl3*
+      - usr/lib/**/libfreeblpriv3*
+      - usr/lib/**/libsoftokn3*
+      # Linked by libbd_crypto and libvolume_key
+      - usr/lib/**/libsmime3.so*
+      - usr/lib/**/libssl3.so*
+      # Linked by libbd_crypto and libvolume_key
+      - usr/lib/**/libgpgme.so*
 
 slots:
   udisks2-dbus:
@@ -112,6 +130,9 @@ parts:
       - libblockdev3
       - libblockdev-smart3
       - libgudev-1.0-0
+    prime:
+      - -usr/lib/x86_64-linux-gnu/libnssckbi.so*
+      - -usr/lib/x86_64-linux-gnu/libnssdbm3*
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/usr


### PR DESCRIPTION
@nicoharnois, @alfonsosanchezbeato

Two unused libraries (`libnssckbi`, `libnssdbm3`) are excluded from prime.

The remaining linter warnings are present in the core24 snap as well, these libraries are loaded via dlopen at runtime are added to `lint.ignore` to suppress the warnings.

Local spread test is passing.
```
2026-04-20 09:36:39 Project content is packed for delivery (28.14MB).
2026-04-20 09:36:39 If killed, discard servers with: spread -reuse-pid=74857 -discard
2026-04-20 09:36:39 Allocating qemu:ubuntu-core-26-64...
2026-04-20 09:36:39 Nico debug: QEMU cmdline: /usr/bin/qemu-system-x86_64 -drive if=pflash,format=raw,file=/home/marko.puric@canonical.com/OVMF_VARS.fd,unit=1 -drive if=pflash,format=raw,readonly=on,file=/usr/share/OVMF/OVMF_CODE_4M.fd,unit=0 -nographic -enable-kvm -snapshot -m 4096 -net nic -net user,hostfwd=tcp:127.0.0.1:59345-:22 -serial telnet:127.0.0.1:59445,server,nowait -monitor telnet:127.0.0.1:59545,server,nowait /home/marko.puric@canonical.com/.spread/qemu/ubuntu-core-26-64.img
2026-04-20 09:36:39 Serial and monitor for qemu:ubuntu-core-26-64 available at ports 59445 and 59545.
2026-04-20 09:36:39 Waiting for qemu:ubuntu-core-26-64 to make SSH available...
2026-04-20 09:36:40 Allocated qemu:ubuntu-core-26-64.
2026-04-20 09:36:40 Connecting to qemu:ubuntu-core-26-64...
2026-04-20 09:37:51 Connected to qemu:ubuntu-core-26-64 at localhost:59345.
2026-04-20 09:37:51 Sending project content to qemu:ubuntu-core-26-64...
2026-04-20 09:37:53 Preparing qemu:ubuntu-core-26-64 (qemu:ubuntu-core-26-64)...
2026-04-20 09:37:53 Preparing qemu:ubuntu-core-26-64:tests/smoke (qemu:ubuntu-core-26-64)...
2026-04-20 09:38:00 Executing qemu:ubuntu-core-26-64:tests/smoke (qemu:ubuntu-core-26-64) (1/1)...
2026-04-20 09:38:01 Restoring qemu:ubuntu-core-26-64:tests/smoke (qemu:ubuntu-core-26-64)...
2026-04-20 09:38:04 Discarding qemu:ubuntu-core-26-64...
2026-04-20 09:38:04 Successful tasks: 1
2026-04-20 09:38:04 Aborted tasks: 0
```