### PR TITLE
snapcraft.yaml: use arch glob in prime exclusions

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -131,8 +131,8 @@ parts:
       - libblockdev-smart3
       - libgudev-1.0-0
     prime:
-      - -usr/lib/x86_64-linux-gnu/libnssckbi.so*
-      - -usr/lib/x86_64-linux-gnu/libnssdbm3*
+      - -usr/lib/*/libnssckbi.so*
+      - -usr/lib/*/libnssdbm3*
     plugin: autotools
     autotools-configure-parameters:
       - --prefix=/usr


### PR DESCRIPTION
Replace hardcoded x86_64-linux-gnu arch triplet with * in the prime exclusions, so the exclusions work across all architectures.

@nicoharnois @alfonsosanchezbeato @Meulengracht 