### PR TITLE
spread.yaml: updates for UC26

### DIFF
--- a/.github/workflows/publish_edge.yaml
+++ b/.github/workflows/publish_edge.yaml
@@ -3,7 +3,7 @@ name: Publish to edge
 on:
   push:
     branches:
-      - snap-24
+      - snap-26
 
 jobs:
   publish_to_edge:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,7 @@ name: Spread tests
 on:
   pull_request:
     branches:
-      - snap-24
+      - snap-26
 
 jobs:
   build:
@@ -15,3 +15,5 @@ jobs:
         env:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
         uses: canonical/system-snaps-cicd-tools/action-test@main
+        with:
+          spread_suites: "openstack:"

--- a/spread.yaml
+++ b/spread.yaml
@@ -26,7 +26,7 @@ environment:
   TESTSLIB: $PROJECT_PATH/cicd/snapd-lib
   SYSTEMSNAPSTESTLIB: $PROJECT_PATH/cicd/lib
   TESTSTOOLS: $PROJECT_PATH/cicd/snapd-lib/tools
-  PATH: /snap/bin:$PATH:/var/lib/snapd/snap/bin:$PROJECT_PATH/cicd/snapd-lib/tools
+  PATH: /snap/bin:$PATH:/var/lib/snapd/snap/bin:$PROJECT_PATH/cicd/snapd-lib/tools:/usr/lib/python
   TESTSTMP: /var/tmp/snapd-tools
   REUSE_SNAPD: 0
   SRU_VALIDATION: 0
@@ -39,18 +39,47 @@ environment:
   SNAPD_CHANNEL: '$(HOST: echo "${SPREAD_SNAPD_CHANNEL:-edge}")'
 
 backends:
-  google:
-    key: '$(HOST: echo "$SPREAD_GOOGLE_KEY")'
-    location: snapd-spread/us-east1-b
-    plan: n2-standard-2
+  openstack:
+    type: openstack
+    key: '$(HOST: echo "$OS_CREDENTIALS_AMD64_PS7")'
+    plan: shared.xsmall
     halt-timeout: 2h
-    systems:
+    wait-timeout: 10m
+    groups: [default]
+    proxy: ingress-haproxy.ps7.canonical.com
+    cidr-port-rel: [10.151.96.0/21:5000]
+    volume-auto-delete: true
+    environment: &openstack-env
+      SNAPD_USE_PROXY: 'true'
+      HTTP_PROXY: 'http://egress.ps7.internal:3128'
+      HTTPS_PROXY: 'http://egress.ps7.internal:3128'
+      http_proxy: 'http://egress.ps7.internal:3128'
+      https_proxy: 'http://egress.ps7.internal:3128'
+      no_proxy: '127.0.0.1,127.0.0.53,localhost'
+      NO_PROXY: '127.0.0.1,127.0.0.53,localhost'
+      NTP_SERVER: 'ntp.ps7.internal'
+    systems: &openstack-systems
       - ubuntu-core-26-64:
-          image: ubuntu-26.04-64
-          workers: 8
-          storage: 20G
+          image: snapd-spread/ubuntu-26.04-64-uefi
+          workers: 1
     prepare: |
-      # Builds UC image on top of classic
+      # Builds UC image on top of classic 26.04
+      "$TESTSLIB"/prepare-restore.sh --prepare-suite
+
+  openstack-dev:
+    type: openstack
+    key: '$(HOST: echo "$OS_CREDENTIALS_STG_AMD64_PS7")'
+    plan: shared.xsmall
+    halt-timeout: 2h
+    wait-timeout: 10m
+    groups: [default]
+    proxy: ingress-haproxy.ps7.canonical.com
+    cidr-port-rel: [10.151.54.0/24:4000]
+    volume-auto-delete: true
+    environment: *openstack-env
+    systems: *openstack-systems
+    prepare: |
+      # Builds UC image on top of classic 26.04
       "$TESTSLIB"/prepare-restore.sh --prepare-suite
 
   qemu:
@@ -85,8 +114,8 @@ prepare: |
   "$SYSTEMSNAPSTESTLIB"/prepare.sh
 
 prepare-each: |
-  snap wait system seed.loaded
-  snap install --dangerous "${PROJECT_PATH}/${SNAP_NAME}"*_amd64.snap
+  # TODO: switch to 26/stable once the snap is promoted there
+  "$SYSTEMSNAPSTESTLIB"/prepare-each.sh "$SNAP_NAME" 26/beta
   snap connect udisks2:udisks2-client udisks2:udisks2
   snap connect udisks2:hardware-observe
   snap connect udisks2:mount-observe


### PR DESCRIPTION
- add openstack and openstack-dev backends for github actions
- fetch snap from 26/beta channel until it is promoted to stable